### PR TITLE
Added HTTP GET methods for StatusLogService

### DIFF
--- a/src/Services/StatusLogService.php
+++ b/src/Services/StatusLogService.php
@@ -4,6 +4,7 @@ namespace MayMeow\Omglol\Services;
 
 use MayMeow\Omglol\Model\StatusLog\Status;
 use MayMeow\Omglol\Model\StatusLog\StatusLog;
+use MayMeow\Omglol\Model\StatusLog\StatusResponse;
 use MayMeow\Omglol\Services\Http\OmgLolClient;
 use MayMeow\Omglol\Services\Http\OmgLolClientInterface;
 use Meow\Hydrator\Hydrator;
@@ -51,6 +52,16 @@ class StatusLogService implements StatusLogServiceInterface
         $statuses = $this->hydrator->hydrate(StatusLog::class, json_decode($response->getContent(), true));
 
         return $statuses->response->statuses;
+    }
+
+    public function getBio(string $address): StatusResponse
+    {
+        $response = $this->client->get(sprintf('/address/%s/statuses/bio', $address));
+
+        /** @var StatusLog $status */
+        $status = $this->hydrator->hydrate(StatusLog::class, json_decode($response->getContent(), true));
+
+        return $status->response;
     }
 
 

--- a/src/Services/StatusLogService.php
+++ b/src/Services/StatusLogService.php
@@ -64,5 +64,13 @@ class StatusLogService implements StatusLogServiceInterface
         return $status->response;
     }
 
+    public function getLatest(): array
+    {
+        $response = $this->client->get('/statuslog/latest');
 
+        /** @var StatusLog $status */
+        $status = $this->hydrator->hydrate(StatusLog::class, json_decode($response->getContent(), true));
+
+        return $status->response->statuses;
+    }
 }

--- a/src/Services/StatusLogService.php
+++ b/src/Services/StatusLogService.php
@@ -2,6 +2,7 @@
 
 namespace MayMeow\Omglol\Services;
 
+use MayMeow\Omglol\Model\StatusLog\Status;
 use MayMeow\Omglol\Model\StatusLog\StatusLog;
 use MayMeow\Omglol\Services\Http\OmgLolClient;
 use MayMeow\Omglol\Services\Http\OmgLolClientInterface;
@@ -20,6 +21,16 @@ class StatusLogService implements StatusLogServiceInterface
             $this->client = new OmgLolClient($token);
         }
         $this->hydrator = new Hydrator();
+    }
+
+    public function getSIngleStatus(string $address, string $statusID): Status
+    {
+        $response = $this->client->get(sprintf('/address/%s/statuses/%s', $address, $statusID));
+
+        /** @var StatusLog $status */
+        $status = $this->hydrator->hydrate(StatusLog::class, json_decode($response->getContent(), true));
+
+        return $status->response->status;
     }
 
     /**
@@ -41,4 +52,6 @@ class StatusLogService implements StatusLogServiceInterface
 
         return $statuses->response->statuses;
     }
+
+
 }

--- a/src/Services/StatusLogServiceInterface.php
+++ b/src/Services/StatusLogServiceInterface.php
@@ -25,7 +25,7 @@ interface StatusLogServiceInterface
 
     //public function updateStatus(): StatusResponse;
 
-    //public function getBio(): StatusResponse;
+    public function getBio(string $address): StatusResponse;
 
     /**
      * retrieve everyones latest statuses

--- a/src/Services/StatusLogServiceInterface.php
+++ b/src/Services/StatusLogServiceInterface.php
@@ -11,7 +11,7 @@ interface StatusLogServiceInterface
      * Fetch a single Statuslog entry
      * address and staus id is required
      */
-    //public function getSIngleStatus(): Status;
+    public function getSIngleStatus(string $address, string $statusID): Status;
 
     /**
      * Undocumented function

--- a/src/Services/StatusLogServiceInterface.php
+++ b/src/Services/StatusLogServiceInterface.php
@@ -30,5 +30,5 @@ interface StatusLogServiceInterface
     /**
      * retrieve everyones latest statuses
      */
-    //public function getLatest(): array;
+    public function getLatest(): array;
 }

--- a/tests/StatusLogServiceTest.php
+++ b/tests/StatusLogServiceTest.php
@@ -65,4 +65,19 @@ class StatusLogServiceTest extends TestCase
         $this->assertInstanceOf(StatusResponse::class, $status);
         $this->assertEquals($testData['response']['bio'], $status->bio);
     }
+
+    public function testGetLatest()
+    {
+        $statuses = $this->statusLogService->getLatest();
+        $testData = TestClient::getTestDataFor('/statuslog/latest');
+
+        $i = 0;
+        foreach ($statuses as $status) {
+            $this->assertInstanceOf(Status::class, $status);
+            $this->assertEquals($testData['response']['statuses'][$i]['id'], $status->id);
+            $i++;
+        }
+
+        $this->assertCount(count($testData['response']['statuses']), $statuses);
+    }
 }

--- a/tests/StatusLogServiceTest.php
+++ b/tests/StatusLogServiceTest.php
@@ -3,6 +3,7 @@
 namespace MayMeow\Omglol\Tests;
 
 use MayMeow\Omglol\Model\StatusLog\Status;
+use MayMeow\Omglol\Model\StatusLog\StatusResponse;
 use MayMeow\Omglol\Services\Http\OmgLolClientInterface;
 use MayMeow\Omglol\Services\StatusLogService;
 use MayMeow\Omglol\Services\StatusLogServiceInterface;
@@ -54,5 +55,14 @@ class StatusLogServiceTest extends TestCase
 
         $this->assertInstanceOf(Status::class, $status);
         $this->assertEquals($testData['response']['status']['id'], $status->id);
+    }
+
+    public function testGetStatuslogBio()
+    {
+        $status = $this->statusLogService->getBio('adam');
+        $testData = TestClient::getTestDataFor('/address/adam/statuses/bio');
+
+        $this->assertInstanceOf(StatusResponse::class, $status);
+        $this->assertEquals($testData['response']['bio'], $status->bio);
     }
 }

--- a/tests/StatusLogServiceTest.php
+++ b/tests/StatusLogServiceTest.php
@@ -46,4 +46,13 @@ class StatusLogServiceTest extends TestCase
 
         $this->assertCount(count($testData['response']['statuses']), $statuses);
     }
+
+    public function testGetSingleStatus()
+    {
+        $status = $this->statusLogService->getSIngleStatus('foo', '6336318079242');
+        $testData = TestClient::getTestDataFor('/address/foo/statuses/6336318079242');
+
+        $this->assertInstanceOf(Status::class, $status);
+        $this->assertEquals($testData['response']['status']['id'], $status->id);
+    }
 }

--- a/tests/TestClient.php
+++ b/tests/TestClient.php
@@ -23,6 +23,10 @@ class TestClient implements OmgLolClientInterface
         if ($url === '/address/adam/statuses/bio') {
             return new TestResponse($this->getStatusLogBio());
         }
+
+        if ($url === '/statuslog/latest') {
+            return new TestResponse($this->getLatest());
+        }
     }
 
     public static function getTestDataFor(string $url): array
@@ -98,7 +102,7 @@ class TestClient implements OmgLolClientInterface
         }';
     }
 
-    public function getSingleStatus()
+    public function getSingleStatus(): string
     {
         return '{
             "request": {
@@ -118,7 +122,7 @@ class TestClient implements OmgLolClientInterface
         }';
     }
 
-    public function getStatusLogBio()
+    public function getStatusLogBio(): string
     {
         return '{
             "request": {
@@ -129,6 +133,37 @@ class TestClient implements OmgLolClientInterface
                 "message": "Here’s the bio for foo’s Statuslog page.",
                 "bio": "# Foo\nThis is my bio!",
                 "css": ""
+            }
+        }';
+    }
+
+    public function getLatest()
+    {
+        return '{
+            "request": {
+                "status_code": 200,
+                "success": true
+            },
+            "response": {
+                "message": "Here are everyone’s latest statuses.",
+                "statuses": [
+                    {
+                        "id": "638ff5cfaa031",
+                        "address": "cm",
+                        "created": "1670378959",
+                        "relative_time": "1 day ago",
+                        "emoji": "🤔",
+                        "content": "Excited about omg.lol!"
+                    },
+                    {
+                        "id": "638ff59bd1be8",
+                        "address": "moe",
+                        "created": "1670378907",
+                        "relative_time": "1 day ago",
+                        "emoji": "👀",
+                        "content": "Browsing [omg.lol - Statuslog](https://home.omg.lol/address/moe/statuslog)."
+                    }
+                ]
             }
         }';
     }

--- a/tests/TestClient.php
+++ b/tests/TestClient.php
@@ -15,6 +15,10 @@ class TestClient implements OmgLolClientInterface
         if ($url === '/statuslog') {
             return new TestResponse($this->getStatusLog());
         }
+
+        if ($url === '/address/foo/statuses/6336318079242') {
+            return new TestResponse($this->getSingleStatus());
+        }
     }
 
     public static function getTestDataFor(string $url): array
@@ -86,6 +90,26 @@ class TestClient implements OmgLolClientInterface
                         "content": "Watching Ink Master"
                     }
                 ]
+            }
+        }';
+    }
+
+    public function getSingleStatus()
+    {
+        return '{
+            "request": {
+                "status_code": 200,
+                "success": true
+            },
+            "response": {
+                "message": "Here’s the status at foo.status.lol/6336318079242.",
+                "status": {
+                    "id": "6336318079242",
+                    "address": "foo",
+                    "created": "1664496000",
+                    "emoji": "☕️",
+                    "content": "Enjoying my coffee!"
+                }
             }
         }';
     }

--- a/tests/TestClient.php
+++ b/tests/TestClient.php
@@ -19,6 +19,10 @@ class TestClient implements OmgLolClientInterface
         if ($url === '/address/foo/statuses/6336318079242') {
             return new TestResponse($this->getSingleStatus());
         }
+
+        if ($url === '/address/adam/statuses/bio') {
+            return new TestResponse($this->getStatusLogBio());
+        }
     }
 
     public static function getTestDataFor(string $url): array
@@ -110,6 +114,21 @@ class TestClient implements OmgLolClientInterface
                     "emoji": "☕️",
                     "content": "Enjoying my coffee!"
                 }
+            }
+        }';
+    }
+
+    public function getStatusLogBio()
+    {
+        return '{
+            "request": {
+                "status_code": 200,
+                "success": true
+            },
+            "response": {
+                "message": "Here’s the bio for foo’s Statuslog page.",
+                "bio": "# Foo\nThis is my bio!",
+                "css": ""
             }
         }';
     }


### PR DESCRIPTION
Added `GET` methods for status log

- [Retrieve an individual status for an address](https://api.omg.lol/#noauth-get-statuslog-retrieve-an-individual-status-for-an-address) `getSIngleStatus(string $address, string $statusID): Status;`
- [Retrieve all statuses for an address](https://api.omg.lol/#noauth-get-statuslog-retrieve-all-statuses-for-an-address) `getAllStatuses(?string $address = null): array;`
- [Retrieve a Statuslog bio](https://api.omg.lol/#noauth-get-statuslog-retrieve-a-statuslog-bio) `function getBio(string $address): StatusResponse;`
- [Retrieve the entire statuslog](https://api.omg.lol/#noauth-get-statuslog-retrieve-the-entire-statuslog) `getAllStatuses(?string $address = null): array;` if address is not provided.
- [Retrieve everyone’s latest status](https://api.omg.lol/#noauth-get-statuslog-retrieve-everyone%E2%80%99s-latest-status) `public function getLatest(): array;`